### PR TITLE
improving shared class creation.

### DIFF
--- a/dice.php
+++ b/dice.php
@@ -32,8 +32,8 @@ class Dice {
 			
 			$this->cache[$component] = function($args, $forceNewInstance) use ($component, $rule, $class, $constructor, $params) {
 				if ($rule->shared) {
-					$this->instances[$component] = $object = $class->isInternal() && $constructor ? $class->newInstanceArgs($params($args)) : $class->newInstanceWithoutConstructor();
-					if ($constructor && !$class->isInternal()) $constructor->invokeArgs($object, $params($args));
+					$this->instances[$component] = $object = $class->newInstanceWithoutConstructor();
+					if ($constructor) $constructor->invokeArgs($object, $params($args));
 				}
 				else $object = $params ? new $class->name(...$params($args)) : new $class->name;
 				if ($rule->call) foreach ($rule->call as $call) $class->getMethod($call[0])->invokeArgs($object, call_user_func($this->getParams($class->getMethod($call[0]), new Rule), $this->expand($call[1])));

--- a/dice.php
+++ b/dice.php
@@ -30,17 +30,21 @@ class Dice {
 			$constructor = $class->getConstructor();			
 			$params = $constructor ? $this->getParams($constructor, $rule) : null;
 			
-			$this->cache[$component] = function($args, $forceNewInstance) use ($component, $rule, $class, $constructor, $params) {
+			$this->cache[$component] = function($args) use ($component, $rule, $class, $constructor, $params) {
 				if ($rule->shared) {
-					$this->instances[$component] = $object = $class->newInstanceWithoutConstructor();
-					if ($constructor) $constructor->invokeArgs($object, $params($args));
+					if ($constructor) {
+						$this->instances[$component] = $object = $class->newInstanceWithoutConstructor();
+						$constructor->invokeArgs($object, $params($args));
+					} else {
+						$this->instances[$component] = $object = new $class->name;
+					}
 				}
 				else $object = $params ? new $class->name(...$params($args)) : new $class->name;
 				if ($rule->call) foreach ($rule->call as $call) $class->getMethod($call[0])->invokeArgs($object, call_user_func($this->getParams($class->getMethod($call[0]), new Rule), $this->expand($call[1])));
 				return $object;
 			};			
 		}
-		return $this->cache[$component]($args, $forceNewInstance);
+		return $this->cache[$component]($args);
 	}
 	
 	private function expand($param, array $share = []) {

--- a/tests/dicetest.php
+++ b/tests/dicetest.php
@@ -642,5 +642,19 @@ class DiceTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertInstanceOf('MyDirectoryIteratorWithTrait', $dir);
 	}
+
+	public function testSharedFinalInternalClass()
+	{
+		$rule = new \Dice\Rule;
+		$rule->shared = true;
+
+		$class = 'mysqli_driver';
+		$this->dice->addRule($class, $rule);
+
+		$driver = $this->dice->create($class);
+
+		$this->assertInstanceOf($class, $driver);
+	}
 	
 }
+


### PR DESCRIPTION
In PHP 5.6 we can instance every class with `$class->newInstanceWithoutConstructor()` even internal classes. So there is no need to call `$class->isInternal()` anymore.

While I'm not aware of any performance issues, I think this commit can improve readability.