### PR TITLE
Allow to pass NULL for a parameter with type hinting and default value NULL

### DIFF
--- a/dice.php
+++ b/dice.php
@@ -61,16 +61,16 @@ class Dice {
 	private function getParams(\ReflectionMethod $method, Rule $rule) {	
 		$subs = empty($rule->substitutions) ? null :$rule->substitutions;
 		$paramClasses = [];
-		foreach ($method->getParameters() as $param) $paramClasses[] = $param->getClass() ? $param->getClass()->name : null;
+		foreach ($method->getParameters() as $param) $paramClasses[] = [$param->getClass() ? $param->getClass()->name : null, $param->allowsNull()];
 		
 		return function($args) use ($paramClasses, $rule, $subs) {
 			$share = empty($rule->shareInstances) ? [] : array_map([$this, 'create'], $rule->shareInstances);
 			if (!empty($share) || !empty($rule->constructParams)) $args = array_merge($args, $this->expand($rule->constructParams, $share), $share);
 			$parameters = [];
 			
-			foreach ($paramClasses as $class) {
+			foreach ($paramClasses as list($class, $allowsNull)) {
 				if (!empty($args)) for ($i = 0; $i < count($args); $i++) {
-					if ($class && $args[$i] instanceof $class) {
+					if ($class && $args[$i] instanceof $class || !$args[$i] && $allowsNull) {
 						$parameters[] = array_splice($args, $i, 1)[0];
 						continue 2;
 					}

--- a/tests/dicetest.php
+++ b/tests/dicetest.php
@@ -181,6 +181,14 @@ class DiceTest extends PHPUnit_Framework_TestCase {
 		$obj = $this->dice->create('MethodWithDefaultValue');
 		$this->assertEquals($obj->foo, 'bar');
 	}
+
+	public function testDefaultNullAssigned() {
+		$rule = new \Dice\Rule;
+        $rule->constructParams = [new Dice\Instance('A'), null];
+		$this->dice->addRule('MethodWithDefaultNull', $rule);
+		$obj = $this->dice->create('MethodWithDefaultNull');
+		$this->assertNull($obj->b);
+	}
 	
 	public function testSharedNamed() {
 		$rule = new \Dice\Rule;

--- a/tests/dicetest.php
+++ b/tests/dicetest.php
@@ -184,7 +184,7 @@ class DiceTest extends PHPUnit_Framework_TestCase {
 
 	public function testDefaultNullAssigned() {
 		$rule = new \Dice\Rule;
-        $rule->constructParams = [new Dice\Instance('A'), null];
+		$rule->constructParams = [new Dice\Instance('A'), null];
 		$this->dice->addRule('MethodWithDefaultNull', $rule);
 		$obj = $this->dice->create('MethodWithDefaultNull');
 		$this->assertNull($obj->b);

--- a/tests/testdata/testclasses.php
+++ b/tests/testdata/testclasses.php
@@ -81,6 +81,16 @@ class MethodWithDefaultValue {
 	}
 }
 
+class MethodWithDefaultNull {
+	public $a;
+	public $b;
+
+	public function __construct(A $a, B $b = null) {
+		$this->a = $a;
+		$this->b = $b;
+	}
+}
+
 class MyDirectoryIterator extends DirectoryIterator {
 	
 }


### PR DESCRIPTION
Whenever a function parameter with a type hint has a default value of `NULL`, passing `NULL` instead of a valid class instance is allowed (according the the PHP documentation at http://php.net/manual/en/language.oop5.typehinting.php). On the other hand, the `instanceof` operator does of course not recognize `NULL` as an instance of a given class.

This pull request would allow to pass NULL via the `contructParams` whenever the default value is set to `NULL`; I'm not sure how to properly solve this also for the substitutions. It should be easy to forward-port this to `master`; unfortunately, I don't have a PHP 5.6 setup readily available at the moment.