### PR TITLE
Enabling Shared Instances in Nested Classes

### DIFF
--- a/tests/dicetest.php
+++ b/tests/dicetest.php
@@ -531,6 +531,15 @@ class DiceTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals($shareTest->share1->shared->uniq, $shareTest->share2->shared->uniq);
 		
 	}
+
+	public function testShareInstancesNested() {
+		$rule = new \Dice\Rule();
+		$rule->shareInstances = ['F'];
+		$this->dice->addRule('A4',$rule);
+		$a = $this->dice->create('A4');
+		$this->assertTrue($a->m1->f === $a->m2->e->f);
+	}
+
 	
 	public function testShareInstancesMultiple() {
 		$rule = new \Dice\Rule();

--- a/tests/testdata/testclasses.php
+++ b/tests/testdata/testclasses.php
@@ -246,6 +246,33 @@ class A3 {
 		$this->c = $c;
 	}
 }
+
+class A4 {
+	public $m1;
+	public $m2;
+
+	public function __construct(M1 $m1, M2 $m2) {
+		$this->m1 = $m1;
+		$this->m2 = $m2;
+	}
+}
+
+class M1 {
+	public $f;
+
+	public function __construct(F $f) {
+		$this->f = $f;
+	}
+}
+
+class M2 {
+	public $e;
+
+	public function __construct(E $e) {
+		$this->e = $e;
+	}
+}
+
 class A {
 	public $b;
 


### PR DESCRIPTION
This PR would allow to specify that `class E` can be shared within every created `class A` (reading the documentation "_[...] mark [...] as shared within each instance of an object tree_" I would expect this to work) in the scenario

```php
class A {
    private $b;
    private $c;

    public function __construct(B $b, C $c) {
        $this->b = $b;
        $this->c = $c;
    }
}
class B {
    private $d;

    public function __construct(D $d) {
        $this->d = $d;
    }
}
class C {
    private $e;

    public function __construct(E $e) {
        $this->e = $e;
    }
}
class D {
    private $e;

    public function __construct(E $e) {
        $this->e = $e;
    }
}
class E {}
```
by using the following configuration

```php
$dice = new \Dice\Dice;
$rule = new \Dice\Rule;
$rule->shareInstances = ['E'];
$dice->addRule('A', $rule);
```

Unfortunately, I could not come up with a more elegant way to adapt the code; so, if the same can be achieved with a simpler change feel free to reject this.