### PR TITLE
fixed bug where empty array was being seen as null.

### DIFF
--- a/Dice.php
+++ b/Dice.php
@@ -63,7 +63,7 @@ class Dice {
 			
 			foreach ($paramInfo as list($class, $allowsNull, $sub, $new)) {
 				if ($args) for ($i = 0; $i < count($args); $i++) {
-					if ($class && $args[$i] instanceof $class || !$args[$i] && $allowsNull) {
+					if ($class && $args[$i] instanceof $class || ($args[$i] === null && $allowsNull)) {
 						$parameters[] = array_splice($args, $i, 1)[0];
 						continue 2;
 					}


### PR DESCRIPTION
There was an issue where empty arrays were being seen as null and causing problems on variables that aren't type hinted.

Example code:

```php
class Foo {
	public function __construct($a, $b, $c) {
		print_r(func_get_args());
	}	
}


$dic->create('Foo', [ ['A'], [], ['C']]);

```

This should print:


```

Array
(
    [0] => Array
        (
            [0] => A
        )

    [1] => Array
        (
        )

    [2] => Array
        (
            [0] => C
        )

)


```

However, instead it prints this:

```php
Array
(
    [0] => Array
        (
        )

    [1] => Array
        (
            [0] => A
        )

    [2] => Array
        (
            [0] => C
        )

)
```

This is because this line:

!$args[$i] is seeing an empty array as null. I have updated Dice to use ($args[$i] === null && $allowsNull) instead.

The test cases still pass and it looks like it should work as intended but any comments are welcome!
