### PR TITLE
ShareInstances Problem with non-object constructor Arguments

### DIFF
--- a/dice.php
+++ b/dice.php
@@ -65,7 +65,7 @@ class Dice {
 		}		
 		return function($args, $share = []) use ($paramInfo, $rule) {
 			if ($rule->shareInstances) $share = array_merge($share, array_map([$this, 'create'], $rule->shareInstances));			
-			if ($share || $rule->constructParams) $args = array_merge($args, $this->expand($rule->constructParams, $share), $share);
+			if ($share || $rule->constructParams) $args = array_merge($this->expand($rule->constructParams, $share), $args, $share);
 			$parameters = [];
 			
 			foreach ($paramInfo as $param) {

--- a/tests/DiceTest.php
+++ b/tests/DiceTest.php
@@ -312,6 +312,22 @@ class DiceTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals($obj->foo, 'foo');
 		$this->assertEquals($obj->bar, 'bar');
 	}
+
+	public function testConstructParamsNested() {
+		$rule = new \Dice\Rule;
+		$rule->constructParams = array('foo', 'bar');
+		$this->dice->addRule('RequiresConstructorArgsA', $rule);
+
+		$rule = new \Dice\Rule;
+		$rule->shareInstances = array('D');
+		$this->dice->addRule('ParamRequiresArgs', $rule);
+		
+		$obj = $this->dice->create('ParamRequiresArgs');
+		
+		$this->assertEquals($obj->a->foo, 'foo');
+		$this->assertEquals($obj->a->bar, 'bar');
+	}
+
 	
 	public function testConstructParamsMixed() {
 		$rule = new \Dice\Rule;
@@ -516,6 +532,8 @@ class DiceTest extends PHPUnit_Framework_TestCase {
 		$this->assertInstanceOf('A', $bestMatch->a);
 	}
 	
+
+    
 	
 	public function testShareInstances() {
 		$rule = new \Dice\Rule();

--- a/tests/testdata/testclasses.php
+++ b/tests/testdata/testclasses.php
@@ -339,6 +339,14 @@ class RequiresConstructorArgsB {
 	}
 }
 
+class ParamRequiresArgs {
+    public $a;
+    
+    public function __construct(D $d, RequiresConstructorArgsA $a) {
+        $this->a = $a;
+    }
+}
+
 interface interfaceTest {}
 
 class InterfaceTestClass implements interfaceTest {


### PR DESCRIPTION
Coming back to the thing I actually wanted to fix in the first place; looking at

```php
class A {

    public $c;

    public function __construct(B $b, C $c) {
        $this->c = $c;
    }
    
}

class B {}

class C {

    public $foo = '';

    public function __construct($foo) {
        $this->foo = $foo;
    }

}

$dice = new \Dice\Dice;

$rule = new \Dice\Rule;
$rule->constructParams[] = 'string';
$dice->addRule('C',$rule);

$rule = new \Dice\Rule;
$rule->shareInstances = array('B');
$dice->addRule('A',$rule);

$a = $dice->create('A');
```

I would expect to have an instance of `C` where `$foo == 'string'` instead it contained an instance of `B`. This is fixed by re-ordering the array merge and always consider explicit constructor arguments first.