### PR TITLE
No explicit Constructor Parameter Passing down the Object Graph

### DIFF
--- a/tests/DiceTest.php
+++ b/tests/DiceTest.php
@@ -697,6 +697,19 @@ class DiceTest extends PHPUnit_Framework_TestCase {
 		$this->assertInstanceOf('MyDirectoryIteratorWithTrait', $dir);
 	}
 
+	public function testConstructParamsPrecedence() {
+		$rule = new \Dice\Rule;
+		$rule->constructParams = ['A', 'B'];
+		$this->dice->addRule('RequiresConstructorArgsA', $rule);
+
+		$a1 = $this->dice->create('RequiresConstructorArgsA');
+		$this->assertEquals('A', $a1->foo);
+		$this->assertEquals('B', $a1->bar);
+
+		$a2 = $this->dice->create('RequiresConstructorArgsA', ['C', 'D']);
+		$this->assertEquals('C', $a2->foo);
+		$this->assertEquals('D', $a2->bar);
+	}
 
 }
 

--- a/tests/DiceTest.php
+++ b/tests/DiceTest.php
@@ -81,6 +81,15 @@ class DiceTest extends PHPUnit_Framework_TestCase {
 		$this->assertInstanceOf('Bar77', $foo->bar);
 		$this->assertEquals('Z', $foo->bar->a);
 	}
+
+	public function testConsumeArgs() {
+		$rule = new \Dice\Rule;
+		$rule->constructParams = ['A'];		
+		$this->dice->addRule('ConsumeArgsSub', $rule);
+		$foo = $this->dice->create('ConsumeArgsTop',['B']);
+		
+		$this->assertEquals('A', $foo->a->s);
+	}
 	
 	
 	public function testAssignSharedNamed() {

--- a/tests/testdata/testclasses.php
+++ b/tests/testdata/testclasses.php
@@ -369,3 +369,20 @@ trait MyTrait {
 class MyDirectoryIteratorWithTrait extends DirectoryIterator {
 	use MyTrait;
 }
+
+class ConsumeArgsTop {
+    public $s;
+    public $a;
+
+    public function __construct(ConsumeArgsSub $a, $s) {
+        $this->a = $a;
+        $this->s = $s;
+    }
+}
+class ConsumeArgsSub {
+    public $s;
+
+    public function __construct($s) {
+        $this->s = $s;
+    }
+}


### PR DESCRIPTION
After the discussion in #47 I started thinking whether the following really is a valid use case

```php
class A {
    public $b;
    public $str;
    public function __construct(B $b, $str) {
        $this->b = $b;
        $this->str = $str;
    }
}

class B {
    public $str;
    public function __construct($str) {
        $this->str = $str;
    }
}
$a = $dice->create('A',['A','B']);

echo $a->b->str;
```
if not then the explicit parameters given to the `create` call really do not need to be passed down the object graph (shared instances go via `$shared` anyway).

This PR would change this (it is not documented otherwise and no test fails) and thus restore the expected behaviour as discussed in #47 while leaving all other shared instance fixes intact.