### PR TITLE
create method should handle null arguments correctly

### DIFF
--- a/Dice.php
+++ b/Dice.php
@@ -53,16 +53,16 @@ class Dice {
 		$paramInfo = [];
 		foreach ($method->getParameters() as $param) {
 			$class = $param->getClass() ? $param->getClass()->name : null;
-			$paramInfo[] = [$class, $param->allowsNull(), array_key_exists($class, $rule->substitutions), in_array($class, $rule->newInstances)];
+            $paramInfo[] = [$class, $param->isDefaultValueAvailable() && $param->getDefaultValue() === null, array_key_exists($class, $rule->substitutions), in_array($class, $rule->newInstances)];
 		}
 		return function($args, $share = []) use ($paramInfo, $rule) {
 			if ($rule->shareInstances) $share = array_merge($share, array_map([$this, 'create'], $rule->shareInstances));
 			if ($share || $rule->constructParams) $args = array_merge($args, $this->expand($rule->constructParams, $share), $share);
 			$parameters = [];
 
-			foreach ($paramInfo as list($class, $allowsNull, $sub, $new)) {
+			foreach ($paramInfo as list($class, $defaultsToNull, $sub, $new)) {
 				if ($args && $count = count($args)) for ($i = 0; $i < $count; $i++) {
-					if ($class && $args[$i] instanceof $class || ($args[$i] === null && $allowsNull)) {
+					if ($class && $args[$i] instanceof $class || ($args[$i] === null && $defaultsToNull)) {
 						$parameters[] = array_splice($args, $i, 1)[0];
 						continue 2;
 					}

--- a/tests/DiceTest.php
+++ b/tests/DiceTest.php
@@ -56,7 +56,7 @@ class DiceTest extends PHPUnit_Framework_TestCase {
 	
 		$this->assertInstanceOf('MyDirectoryIterator', $dir);
 	}
-	
+
 	
 	public function testInternalClassExtendedConstructor() {
 		$rule = new \Dice\Rule;
@@ -68,6 +68,30 @@ class DiceTest extends PHPUnit_Framework_TestCase {
 	
 		$this->assertInstanceOf('MyDirectoryIterator2', $dir);
 	}
+
+    public function testAcceptsTwoArguments() {
+        $rule = new \Dice\Rule;
+        $rule->constructParams = ['First', 'Second'];
+
+        $this->dice->addRule('TwoArguments', $rule);
+
+        $class = $this->dice->create('TwoArguments');
+
+        $this->assertEquals('First', $class->first);
+        $this->assertEquals('Second', $class->second);
+    }
+
+    public function testAcceptsTwoArgumentsWithNull() {
+        $rule = new \Dice\Rule;
+        $rule->constructParams = ['First', null];
+
+        $this->dice->addRule('TwoArguments', $rule);
+
+        $class = $this->dice->create('TwoArguments');
+
+        $this->assertEquals('First', $class->first);
+        $this->assertEquals(null, $class->second);
+    }
 	
 	public function testNoMoreAssign() {
 		$rule = new \Dice\Rule;

--- a/tests/TestData/TestClasses.php
+++ b/tests/TestData/TestClasses.php
@@ -12,6 +12,15 @@ class NoConstructor {
 	public $a = 'b';
 }
 
+class TwoArguments {
+    public $first;
+    public $second;
+
+    public function __construct($first, $second) {
+        $this->first = $first;
+        $this->second = $second;
+    }
+}
 
 class CyclicA {
 	public $b;


### PR DESCRIPTION
#62 describes that the `getParams` method consumes an argument from `$args` array if it is null and the parameter of the constructed object is nullable (`$args[$i] === null && $allowsNull`). This is clearly a bug.

As far as I can see this line is only used in the `testDefaultNullAssigned` test for creating an object like `MethodWillDefaultNull`:

    class MethodWithDefaultNull {
		public $a;
		public $b;
		public function __construct(A $a, B $b = null) {
			$this->a = $a;
			$this->b = $b;
		}
	}

So we need to know, if a default parameter with a null value does exists. In that case we can consume the null value from the `$args` array. Replacing `ReflectionParameter->allowsNull()` with `ReflectionParameter->isDefaultValueAvailable() && ReflectionParameter->getDefaultValue() === null` should do the trick.