### PR TITLE
Logic Fix for Order Precedence

### DIFF
--- a/dice.php
+++ b/dice.php
@@ -71,7 +71,7 @@ class Dice {
 			foreach ($paramInfo as $param) {
 				list($class, $allowsNull, $sub, $new) = $param;
 				if ($args) for ($i = 0; $i < count($args); $i++) {
-					if ($class && $args[$i] instanceof $class || !$args[$i] && $allowsNull) {
+                    if ($class && ($args[$i] instanceof $class || is_null($args[$i]) && $allowsNull) ) {
 						$parameters[] = array_splice($args, $i, 1)[0];
 						continue 2;
 					}

--- a/tests/DiceTest.php
+++ b/tests/DiceTest.php
@@ -218,6 +218,19 @@ class DiceTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals($obj->a, 'first');
 		$this->assertNull($obj->b);
 	}
+
+    public function testTwoDefaultNullClass() {
+		$obj = $this->dice->create('MethodWithTwoDefaultNullC');
+        $this->assertNull($obj->a);
+		$this->assertInstanceOf('NB',$obj->b);
+    }
+
+    public function testTwoDefaultNullClassClass() {
+		$obj = $this->dice->create('MethodWithTwoDefaultNullCC');
+        $this->assertNull($obj->a);
+		$this->assertInstanceOf('NB',$obj->b);
+		$this->assertInstanceOf('NC',$obj->c);
+    }
     
 	public function testSharedNamed() {
 		$rule = new \Dice\Rule;

--- a/tests/DiceTest.php
+++ b/tests/DiceTest.php
@@ -200,8 +200,25 @@ class DiceTest extends PHPUnit_Framework_TestCase {
 		$obj = $this->dice->create('MethodWithDefaultNull');
 		$this->assertNull($obj->b);
 	}
-	
-	
+
+    public function testNullSwap() {
+        $obj = $this->dice->create('RequiresConstructorArgsA', ['string', null]);
+        $this->assertEquals($obj->foo, 'string');
+        $this->assertNull($obj->bar);
+    }
+
+    public function testEmptyArraySwap() {
+        $obj = $this->dice->create('RequiresConstructorArgsA', ['string', []]);
+        $this->assertEquals($obj->foo, 'string');
+        $this->assertEquals($obj->bar, []);
+    }
+
+	public function testTwoDefaultNullAssigned() {
+		$obj = $this->dice->create('MethodWithTwoDefaultNull', ['first', null]);
+        $this->assertEquals($obj->a, 'first');
+		$this->assertNull($obj->b);
+	}
+    
 	public function testSharedNamed() {
 		$rule = new \Dice\Rule;
 		$rule->shared = true;

--- a/tests/testdata/testclasses.php
+++ b/tests/testdata/testclasses.php
@@ -101,6 +101,33 @@ class MethodWithTwoDefaultNull {
 	}
 }
 
+class NB {}
+
+class NC {}
+
+class MethodWithTwoDefaultNullC {
+	public $a;
+	public $b;
+
+	public function __construct($a = null, NB $b = null) {
+		$this->a = $a;
+		$this->b = $b;
+	}
+}
+
+class MethodWithTwoDefaultNullCC {
+	public $a;
+	public $b;
+	public $c;
+
+	public function __construct($a = null, NB $b = null, NC $c = null) {
+		$this->a = $a;
+		$this->b = $b;
+		$this->c = $c;
+	}
+}
+
+
 class MyDirectoryIterator extends DirectoryIterator {
 	
 }

--- a/tests/testdata/testclasses.php
+++ b/tests/testdata/testclasses.php
@@ -91,6 +91,16 @@ class MethodWithDefaultNull {
 	}
 }
 
+class MethodWithTwoDefaultNull {
+	public $a;
+	public $b;
+
+	public function __construct($a = null, $b = null) {
+		$this->a = $a;
+		$this->b = $b;
+	}
+}
+
 class MyDirectoryIterator extends DirectoryIterator {
 	
 }


### PR DESCRIPTION
This fixes the issues described in #62 and also considers the test case in #63.

In general it seems to make sense to give the user-defined ordering of the parameters precedence when matching possible arguments over NULL matches.